### PR TITLE
Fixed calldocker so it does not break with Run_multi

### DIFF
--- a/core/calldocker.py
+++ b/core/calldocker.py
@@ -47,12 +47,14 @@ def call(container,command,cwd='',paths={},remove=True):
 
     ###run the container
     #try block to run the container
+    output = b''
     try:
         container_obj = client.containers.run(container,command,user=user,volumes=volumes,working_dir=cwd,remove=remove,detach=True,labels={"prog":"sb_toolkit"})
     except:
         #loop through output as it is streamed
         for line in container_obj.logs(stream=True):
-            yield line.decode('utf-8')
+            output += line
     else:
         for line in container_obj.logs(stream=True):
-            yield line.decode('utf-8').strip()
+            output += line
+    return output.decode('utf-8')

--- a/core/sb_programs.py
+++ b/core/sb_programs.py
@@ -27,8 +27,7 @@ class Run:
 
     def run(self):
         try:
-            for line in container_engine.call(f"{self.image}:{self.tag}", self.command, '/data', self.path):
-                print(line)
+            print(container_engine.call(f"{self.image}:{self.tag}", self.command, '/data', self.path))
         except KeyboardInterrupt:
             container_engine.shutdown()
             sys.exit()
@@ -39,7 +38,6 @@ class Run_multi:
         self.command_list = command_list
         self.image = image
         self.tag = tag
-
 
     def run(self,jobs):
         #initalize all workers to ignore signal int since we are handeling the keyboard interrupt ourself

--- a/staphb_toolkit_workflows
+++ b/staphb_toolkit_workflows
@@ -60,6 +60,14 @@ if __name__ == '__main__':
     #parser_all.add_argument('-o',metavar='output', type=str,help="output directory - defaults to working directory")
     #parser_all.add_argument('-t',metavar='threads', type=int,help="number of cpus to use for pipeline - default of 4",default=4)
 
+    #spriggan-----------------------------------------
+    parser_spriggan = subparsers.add_parser('spriggan', help='', add_help=False)
+    parser_spriggan.add_argument('reads', type=str,help="path to the location of the reads in fastq format")
+    parser_spriggan.add_argument('reference', type=str,help="reference fasta for Quast")
+    parser_spriggan.add_argument('-t',metavar='threads', type=int,help="number of threads to use, defaults to 1",default=1)
+    parser_spriggan.add_argument('-o',metavar='output', type=str,help="output directory - defaults to working directory")
+    parser_spriggan.add_argument('-c',metavar='config', type=str,help="path to configuration file")
+
     parser_args = parser.parse_known_args()
     program = parser_args[0].subparser_name
     args = parser_args[0]
@@ -80,3 +88,6 @@ if __name__ == '__main__':
 
     if program == 'dryad_all':
         dryad('all',args.t,args.o,args.reads,args.reference_sequence)
+
+    if program == 'spriggan':
+        spriggan(args.reads,args.reference,args.t,args.o,args.c)

--- a/staphb_toolkit_workflows
+++ b/staphb_toolkit_workflows
@@ -11,6 +11,7 @@ import core.sb_programs as sb_prog
 from workflows.tredegar.tredegar import tredegar
 from workflows.foushee.foushee import foushee
 from workflows.dryad.dryad import dryad
+from workflows.spriggan.spriggan import spriggan
 
 if __name__ == '__main__':
 

--- a/workflows/spriggan/app/lib.py
+++ b/workflows/spriggan/app/lib.py
@@ -1,0 +1,173 @@
+import os,sys
+import time
+import datetime
+from staphb_toolkit.core.sb_programs import Run_multi
+from staphb_toolkit.core.sb_programs import Run
+
+# returns (num jobs,num cpus per job)
+def cpu_count(num):
+    if num <= 1:
+        return 1,1
+    elif num <= 5:
+        return 1,num
+    else:
+        results = []
+        for n in range(2,num):
+            if num % n == 0:
+                results.append(n)
+        if len(results) < 2:
+            return cpu_count(num-1)
+        index = int(len(results)/2)
+        return results[index],int(num/results[index])
+
+def checkexists(path):
+    path = os.path.abspath(path)
+    if not os.path.isdir(path):
+        os.mkdir(path)
+        return False
+    else:
+        return True
+
+# object for tracking the progress of the pipeline
+class StatusTracker:
+    # status code defined
+    # 0 = created directory, ready to start
+    # 1 = species
+    # 2 = trimmed
+    # 3 = assemble
+    # 4 = mlst
+    # 5 = abricate
+    # 6 = quast
+    def __init__(self):
+        self.status_code = {'start':'0','species':'0','trimmed':'0','assemble':'0','mlst':'0','abricate':'0','quast':'0'}
+        self.status_file_path = ''
+
+    def reset_code(self):
+        self.status_code = {'start':'0','species':'0','trimmed':'0','assemble':'0','mlst':'0','abricate':'0','quast':'0'}
+
+    # check if we have completed the requested pipeline, internal function
+    def checkComplete(self,pipeline):
+        if self.status_code['quast'] == '1':
+            return True
+        else:
+            return False
+
+    def write_status_code(self):
+        code_string = ''
+        for key in self.status_code:
+            code_string += self.status_code[key]
+        with open(self.status_file_path,'w') as outstat:
+            outstat.write(code_string)
+
+    def read_status_code(self):
+        with open(self.status_file_path,'r') as instat:
+            code_string = instat.readline()
+        try:
+            c = 0
+            for key in self.status_code:
+                self.status_code[key] = code_string[c]
+                c += 1
+        except:
+            print("Saved status code is longer than possible")
+            sys.exit(2)
+
+    # update the status on a finished process
+    def update_status_done(self,process):
+        self.status_code[process] = '1'
+        self.write_status_code()
+
+    # check the status of completion on a process
+    def check_status(self,process):
+        self.read_status_code()
+        if self.status_code[process] == '1':
+            return True
+        else:
+            return False
+
+    # initalize the tracker object
+    def initialize(self,path,pipeline):
+        # check for a previous run
+        for root,dirs,files in os.walk(path):
+            for dir in dirs:
+                if "spriggan-" in dir:
+                    spriggan_path = os.path.join(root,dir)
+                    self.status_file_path = os.path.join(spriggan_path,'tracker')
+                    try:
+                        self.read_status_code()
+                    except:
+                        print("Cannot read tracker file please delete:")
+                        print(spriggan_path)
+                        print("and try again.")
+                        sys.exit(2)
+                    if not self.checkComplete(pipeline):
+                        print("There is a previous unfinished run, do you wish to continue?")
+                        print(spriggan_path)
+                        continue_run = input("Y/N? ")
+                        if continue_run == 'n' or continue_run == 'N':
+                            pass
+                        elif continue_run == 'y' or continue_run == 'Y':
+                            self.update_status_done(pipeline)
+                            return spriggan_path
+                        else:
+                            print("Not a Y/N, exiting!")
+                            sys.exit(2)
+
+        # create output dir and new tracker
+        self.reset_code()
+        time = datetime.datetime.now()
+        str_time = "{0}{1}{2}{3}{4}".format(time.year,time.month,time.day,time.hour,time.minute)
+        if checkexists(os.path.join(path,"spriggan-"+str_time)):
+            print(os.path.join(path,"spriggan-"+str_time)+" already exists... please try again in 1 min.")
+            sys.exit(2)
+        spriggan_path = os.path.join(path,"spriggan-"+str_time)
+        self.status_file_path = os.path.join(spriggan_path,'tracker')
+        self.update_status_done('start')
+        self.update_status_done(pipeline)
+        return spriggan_path
+
+
+def getfiles(path):
+    # scan path and look for files
+    fastq_files = []
+    fasta_files = []
+    tsv_files = []
+
+    for root,dirs,files in os.walk(path):
+        for file in files:
+            if ".fastq.gz" in file:
+                fastq_files.append(os.path.join(root,file))
+            if ".fa" in file and "spades" not in file:
+                fasta_files.append(os.path.join(root,file))
+            if ".tab" in file:
+                tsv_files.append(os.path.join(root,file))
+
+    if len(fastq_files) > 0:
+        fastq_files.sort()
+        if len(fastq_files) % 2 != 0:
+            print('There is an uneven number of read pairs in {0}. Exiting.'.format(path))
+            sys.exit()
+        paired_reads = []
+        [paired_reads.append([x,y]) for x,y in zip(fastq_files[0::2],fastq_files[1::2])]
+        yield paired_reads
+
+    if len(fasta_files) > 0:
+        yield fasta_files
+
+    if len(tsv_files) > 0:
+        yield tsv_files
+
+def run_and_log(process, logfile, runs, njobs):
+    # save stdout
+    original = sys.stdout
+
+    # set stdout to log file and run process
+    sys.stdout = open(logfile, 'a')
+    print('***********\n')
+    print('-----------\n')
+    print(process+"\n")
+    runs.run(jobs=njobs)
+    print('-----------\n')
+    print('***********\n')
+
+    # reset stdout
+    sys.stdout = original

--- a/workflows/spriggan/spriggan.py
+++ b/workflows/spriggan/spriggan.py
@@ -1,0 +1,404 @@
+import os,sys
+import psutil
+import shutil
+from shutil import which
+import json
+import datetime
+import getpass
+import signal
+import csv
+
+from staphb_toolkit.core import fileparser
+from staphb_toolkit.core.sb_programs import Run
+from staphb_toolkit.core.sb_programs import Run_multi
+from staphb_toolkit.lib import sb_mash_species
+
+from workflows.spriggan.app.lib import StatusTracker as ST
+from workflows.spriggan.app.lib import getfiles,checkexists,cpu_count,run_and_log
+
+def species(read_path,config_path,jobs,cpu_job,spriggan_out):
+    # set up Mash species
+    mash_obj = sb_mash_species.MashSpecies(path=read_path, output_dir=spriggan_out, configuration=config_path)
+
+    # if we don't have mash species completed run it, otherwise parse the file and get the results
+    mash_results = os.path.join(*[spriggan_out, 'mash_output', 'mash_species.csv'])
+    if not os.path.isfile(mash_results):
+        print(f'Making taxonomic predictions')
+        mash_species = mash_obj.run()
+
+    else:
+        mash_species = {}
+        with open(mash_results, 'r') as csvin:
+            reader = csv.reader(csvin, delimiter=',')
+            for row in reader:
+                mash_species[row[0]] = row[1]
+
+# trimming function
+def q_trim(read_path,read_dict,spriggan_config,jobs,cpu_job,spriggan_out):
+    # trimming output path
+    trimmed_path = os.path.join(spriggan_out,'trimmed')
+    input_path = os.path.join(spriggan_out,'input_reads')
+    checkexists(trimmed_path)
+
+    # create path to log file
+    logfile = os.path.join(spriggan_out,'qtrim.log')
+
+    # set up params, docker mounting, image and tag
+    trimmomatic_configuration = spriggan_config['parameters']['trimmomatic']
+
+    trimmomatic_params = trimmomatic_configuration['params']
+    windowsize = trimmomatic_params['windowsize']
+    qscore = trimmomatic_params['qscore']
+    minlength = trimmomatic_params['minlength']
+
+    trimmomatic_mounting = {read_path:'/data',trimmed_path:'/output'}
+    image = trimmomatic_configuration['image']
+    tag = trimmomatic_configuration['tag']
+
+    # set up Trimmomatic command list
+    cmds = []
+
+    for id in read_dict:
+        # sample IDs
+        read1 = os.path.basename(read_dict[id].fwd)
+        read2 = os.path.basename(read_dict[id].rev)
+        sid = read1.split('_')[0]
+
+        # set up cmds
+        main_cmd = f'java -jar /Trimmomatic-0.39/trimmomatic-0.39.jar PE -threads {cpu_job}'
+        args = f' {sid}/{read1} {sid}/{read2} -baseout /output/{sid}.fastq.gz SLIDINGWINDOW:{windowsize}:{qscore} MINLEN:{minlength}'
+        cmds.append(main_cmd + args)
+
+    print(f'Beginning quality trimming reads:\n Number of Jobs: {jobs}\n CPUs/Job: {cpu_job}')
+
+    # create run object and run commands
+    process = 'Trimming with Trimmomatic'
+    runs = Run_multi(command_list=cmds,path=trimmomatic_mounting,image=image,tag=tag)
+    run_and_log(process,logfile,runs,jobs)
+
+    # remove unpaired reads
+    for root,dirs,files in os.walk(trimmed_path):
+        for file in files:
+            if 'U.fastq.gz' in file:
+                os.remove(os.path.join(root,file))
+
+    print('Finished quality trimming reads')
+
+    # update config file
+    spriggan_config['file_io']['output_files']['log_files']['qtrim'] = os.path.abspath(os.path.join(spriggan_out,'qtrim.log'))
+
+# assembly function
+def assemble_reads(read_dict,spriggan_config,jobs,cpu_job,spriggan_out):
+    # get trimmed reads
+    trimmed_path = os.path.join(spriggan_out,'trimmed')
+    trimmed_dict = read_dict
+
+    for id in trimmed_dict:
+        trimmed_dict[id].path = trimmed_path
+        trimmed_dict[id].fwd = os.path.basename(read_dict[id].fwd).replace("_1.fastq.gz", "_1P.fastq.gz")
+        trimmed_dict[id].rev = os.path.basename(read_dict[id].rev).replace("_2.fastq.gz", "_2P.fastq.gz")
+
+    # update config file output
+    if spriggan_config['file_io']['output_files']['trimmed_fastqs'] == None:
+        spriggan_config['file_io']['output_files']['trimmed_fastqs'] = {}
+
+    for id in trimmed_dict:
+        spriggan_config['file_io']['output_files']['trimmed_fastqs'][trimmed_dict[id].id] = [os.path.join(trimmed_path,trimmed_dict[id].fwd),os.path.join(trimmed_path,trimmed_dict[id].rev)]
+
+    # assembly output path
+    assemblies_path = os.path.join(spriggan_out,'assemblies')
+    checkexists(assemblies_path)
+
+    # create log file
+    logfile = os.path.join(spriggan_out,'assembly.log')
+
+    # determine free ram
+    free_ram = int(psutil.virtual_memory()[1]/1000000000)
+    ram_job = int(free_ram / jobs)
+
+    # set up params, Docker mounting, image and tag
+    shovill_configuration = spriggan_config['parameters']['shovill']
+    shovill_params = shovill_configuration['params']
+
+    shovill_mounting = {trimmed_path:'/data',assemblies_path:'/output'}
+    image = shovill_configuration['image']
+    tag = shovill_configuration['tag']
+
+    # set up Shovill command list
+    cmds = []
+
+    for id in trimmed_dict:
+        # sample IDs
+        read1 = os.path.basename(trimmed_dict[id].fwd)
+        read2 = os.path.basename(trimmed_dict[id].rev)
+        sid = read1.split('_')[0]
+
+        # set up cmds
+        cmds.append(f'bash -c \"shovill --R1 /data/{read1} --R2 /data/{read2} --force --outdir /output/{sid} --cpus {cpu_job} --ram {ram_job} && mv /output/{sid}/contigs.fa /output/{sid}/{sid}.fa\"')
+
+    print(f'Beginning assembly of reads:\n Number of Jobs: {jobs}\n CPUs/Job: {cpu_job}')
+
+    # create run object and run commands
+    process = 'Assembly with Shovill'
+    runs = Run_multi(command_list=cmds,path=shovill_mounting,image=image,tag=tag)
+    run_and_log(process,logfile,runs,jobs)
+
+    print('Finished assembling reads')
+
+    # update config file
+    if spriggan_config['file_io']['output_files']['assemblies'] == None:
+        spriggan_config['file_io']['output_files']['assemblies'] = {}
+
+    for id in trimmed_dict:
+        sid = os.path.basename(trimmed_dict[id].fwd.split('_')[0])
+        spriggan_config['file_io']['output_files']['assemblies'][sid] = os.path.join(assemblies_path,f'{sid}/{sid}.fa')
+
+    spriggan_config['file_io']['output_files']['log_files']['assembly'] = os.path.join(spriggan_out,'assembly.log')
+
+def mlst(spriggan_config,jobs,cpu_job,spriggan_out):
+    # get assemblies
+    assemblies_path = os.path.join(spriggan_out,'assemblies')
+    fastas = list(getfiles(assemblies_path))[0]
+
+    # mlst output path
+    mlst_path = os.path.join(spriggan_out,'mlst')
+    checkexists(mlst_path)
+
+    # set up params, docker mounting, image and tag
+    mlst_configuration = spriggan_config['parameters']['mlst']
+    mlst_params = mlst_configuration['params']
+
+    mlst_mounting = {assemblies_path:'/data',mlst_path:'/output'}
+    image = mlst_configuration['image']
+    tag = mlst_configuration['tag']
+
+    # set up string of Shovill results, \s delimited
+    fasta_files = ''
+    for path in fastas:
+        assembly_file = os.path.basename(path)
+        assembly_dir = os.path.basename(os.path.dirname(path))
+        fasta_files = fasta_files + f'/data/{assembly_dir}/{assembly_file} '
+
+    # main command
+    cmd = f'bash -c \"mlst --nopath --quiet ' + fasta_files + '> /output/mlst.tab\"'
+
+    print('Predicting MLST types')
+
+    # set up run and run process
+    mlst_run = Run(command=cmd,path=mlst_mounting,image=image,tag=tag)
+    mlst_run.run()
+
+    print('Finished predicting MLST types')
+
+    # copy output to main dir
+    shutil.copyfile(os.path.join(mlst_path,'mlst.tab'),os.path.join(spriggan_out,'mlst.tab'))
+
+    # update config file
+    spriggan_config['file_io']['output_files']['mlst'] = os.path.join(spriggan_out,'mlst.tab')
+
+# AR prediction function
+def abricate(spriggan_config,jobs,cpu_job,spriggan_out):
+    # get assemblies
+    assemblies_path = os.path.join(spriggan_out,'assemblies')
+    fastas = list(getfiles(assemblies_path))[0]
+
+    # Abricate output path
+    abricate_path = os.path.join(spriggan_out,'abricate')
+    checkexists(abricate_path)
+
+    # set up params, docker mounting, image and tag
+    abricate_configuration = spriggan_config['parameters']['abricate']
+    abricate_mounting = {assemblies_path:'/data',abricate_path:'/output'}
+    image = abricate_configuration['image']
+    tag = abricate_configuration['tag']
+
+    # run Abricate on assemblies
+    print('Predicting AR')
+
+    # set up commands for Abricate
+    cmds = []
+    for path in fastas:
+        # main command
+        assembly_file = os.path.basename(path)
+        assembly_dir = os.path.basename(os.path.dirname(path))
+        sid = assembly_file.split('.')[0]
+        handle = sid + '.tab'
+        cmds.append(f'bash -c \"abricate --db ncbi --quiet /data/{assembly_dir}/{assembly_file} > /output/{handle}\"')
+
+    # set up run and job number
+    abricate_run = Run_multi(command_list=cmds,path=abricate_mounting,image=image,tag=tag)
+    njobs = jobs
+    abricate_run.run(jobs=njobs)
+
+    print('Finished predicting AR')
+
+    # update config file output
+    if spriggan_config['file_io']['output_files']['abricate'] == None:
+        spriggan_config['file_io']['output_files']['abricate'] = {}
+
+    for path in fastas:
+        sid = os.path.basename(path).split('.')[0]
+        spriggan_config['file_io']['output_files']['abricate'][sid] = os.path.join(abricate_path,sid + '.tab')
+
+    # summarize Abricate results
+    print('Summarizing AR prediction')
+
+    abricate_mounting = {abricate_path:'/data',spriggan_out:'/output'}
+
+    # get Abricate results
+    tsvs = list(getfiles(abricate_path))[0]
+
+    # set up string of Abricate results, \s delimited
+    tsv_files = ''
+    for path in tsvs:
+        abricate_file = os.path.basename(path)
+        tsv_files = tsv_files + f'/data/{abricate_file} '
+
+    # main command
+    cmd = f'bash -c \"abricate --summary ' + tsv_files + '> /output/abricate_summary.tab\"'
+
+    # set up run
+    summary_run = Run(command=cmd,path=abricate_mounting,image=image,tag=tag)
+    summary_run.run()
+
+    print('Finished summarizing AR prediction')
+
+    # update config file output
+    spriggan_config['file_io']['output_files']['abricate_summary'] = os.path.abspath(os.path.join(spriggan_out,'abricate_summary.tab'))
+
+# assembly QC function
+def quast(reference,spriggan_config,jobs,cpu_job,spriggan_out):
+    # get assemblies
+    assemblies_path = os.path.join(spriggan_out,'assemblies')
+    fastas = list(getfiles(assemblies_path))[0]
+
+    # path to reference genome
+    ref_path = os.path.dirname(os.path.abspath(reference))
+    ref_genome = os.path.basename(os.path.abspath(reference))
+
+    # quast output path
+    quast_path = os.path.join(spriggan_out,'quast')
+    checkexists(quast_path)
+
+    # create path to log file
+    logfile = os.path.join(spriggan_out,'quast.log')
+
+    # set up params, docker mounting, image and tag
+    quast_configuration = spriggan_config['parameters']['quast']
+    quast_params = quast_configuration['params']
+
+    quast_mounting = {assemblies_path:'/data',ref_path:'/reference',quast_path:'/output'}
+    image = quast_configuration['image']
+    tag = quast_configuration['tag']
+
+    # add reference genome to config file
+    spriggan_config['parameters']['quast']['params']['reference'] = ref_genome
+
+    # set up string of Shovill results, \s delimited
+    fasta_files = ''
+    for path in fastas:
+        assembly_file = os.path.basename(path)
+        assembly_dir = os.path.basename(os.path.dirname(path))
+        fasta_files = fasta_files + f'/data/{assembly_dir}/{assembly_file} '
+
+    # main command
+    cmd = f'quast.py --silent -t {cpu_job} -o /output/ -r /reference/{ref_genome} '+ fasta_files
+
+    # set up run and run process
+    quast_run = Run(command=cmd,path=quast_mounting,image=image,tag=tag)
+    quast_run.run()
+
+    print('Finished running Quast')
+
+    # copy output to main dir
+    shutil.copyfile(os.path.join(quast_path,'transposed_report.tsv'),os.path.join(spriggan_out,'quast_report.tsv'))
+    shutil.copyfile(os.path.join(quast_path,'quast.log'),os.path.join(spriggan_out,'quast.log'))
+
+    # update config file
+    spriggan_config['file_io']['output_files']['quast_report'] = os.path.join(spriggan_out,'quast_report.tsv')
+    spriggan_config['file_io']['output_files']['log_files']['quast'] = os.path.join(spriggan_out,'quast.log')
+
+def spriggan(read_path,reference,threads,outdir,spriggan_config):
+    # set cwd as output dir if outdir is empty
+    try:
+        outdir = os.path.abspath(outdir)
+    except (AttributeError,TypeError) as err:
+        outdir = os.getcwd()
+
+    # get num of jobs and number of cpus per job
+    jobs,cpu_job = cpu_count(threads)
+
+    # initialize tracker
+    pipeline = 'spriggan'
+    tracker = ST()
+    spriggan_out = tracker.initialize(outdir,pipeline)
+    project = os.path.basename(spriggan_out)
+
+    # get fastqs
+    fastq_files = fileparser.ProcessFastqs(read_path)
+
+    # set read_path equal to outdir after reads have been copied there
+    fastq_files.link_reads(output_dir=spriggan_out)
+
+    # path to untrimmed reads
+    read_path = os.path.join(spriggan_out, 'input_reads')
+    read_dict = fastq_files.id_dict()
+
+    # get config file
+    if spriggan_config is not None:
+        config_path = os.path.abspath(spriggan_config)
+    else:
+        # use default
+        config_path = os.path.join(os.path.abspath(os.path.dirname(os.path.realpath(__file__))),'spriggan_config.json')
+
+    # load config file
+    with open(config_path) as config_file:
+        spriggan_config = json.load(config_file)
+
+    # update configuration object with fastqs, reference, run ID, user and date/time
+    spriggan_config['file_io']['input_files']['reference'] = os.path.abspath(reference)
+    spriggan_config['execution']['run_id'] = project
+    spriggan_config['execution']['user'] = getpass.getuser()
+    spriggan_config['execution']['date_time'] = datetime.datetime.today().strftime('%Y-%m-%d')
+
+    if spriggan_config['file_io']['input_files']['fastqs'] == None:
+        spriggan_config['file_io']['input_files']['fastqs'] = {}
+
+    for fastqs in fastq_files.reads:
+        spriggan_config['file_io']['input_files']['fastqs'][fastq_files.reads[fastqs].id] = [fastq_files.reads[fastqs].fwd,fastq_files.reads[fastqs].rev]
+
+    # begin wokflow
+    if not tracker.check_status('species'):
+        print('Predicting species using Mash')
+        species(read_path,config_path,jobs,cpu_job,spriggan_out)
+        tracker.update_status_done('species')
+
+    if not tracker.check_status('trimmed'):
+        print('Trimming reads using Trimmomatic')
+        q_trim(read_path,read_dict,spriggan_config,jobs,cpu_job,spriggan_out)
+        tracker.update_status_done('trimmed')
+
+    if not tracker.check_status('assemble'):
+        print('Assembling reads using Shovill')
+        assemble_reads(read_dict,spriggan_config,jobs,cpu_job,spriggan_out)
+        tracker.update_status_done('assemble')
+
+    if not tracker.check_status('mlst'):
+        print('Predicting MLST types using MLST')
+        mlst(spriggan_config,jobs,cpu_job,spriggan_out)
+        tracker.update_status_done('mlst')
+
+    if not tracker.check_status('abricate'):
+        print('IDing AR genes using Abricate')
+        abricate(spriggan_config,jobs,cpu_job,spriggan_out)
+        tracker.update_status_done('abricate')
+
+    if not tracker.check_status('quast'):
+        print('Evaluating assembly quality using Quast')
+        quast(reference,spriggan_config,jobs,cpu_job,spriggan_out)
+        tracker.update_status_done('quast')
+
+    # write json file to output dir
+    spriggan_config_file = os.path.join(spriggan_out, project+'_config.json')
+    with open(spriggan_config_file, 'w') as jsonOut:
+        jsonOut.write(json.dumps(spriggan_config, indent=3))

--- a/workflows/spriggan/spriggan_config.json
+++ b/workflows/spriggan/spriggan_config.json
@@ -1,0 +1,85 @@
+{
+    "workflow": {
+        "name": "spriggan",
+        "description": "",
+        "documentation": "",
+        "version": "v1.0",
+        "created": "",
+        "license": "",
+        "contributors": {
+            "contributor-01": {
+                "name": "Abigail Shockey",
+                "affiliation": "Wisconsin State Laboratory of Hygiene",
+                "email": "abigail.shockey@slh.wisc.edu"
+            }
+        }
+    },
+    "parameters": {
+        "mash": {
+           "image": "staphb/mash",
+           "tag": "2.1",
+           "mash_sketch": {
+              "sketch_params": ""
+           },
+           "mash_dist": {
+              "dist_params": "",
+              "db": "/db/RefSeqSketchesDefaults.msh"
+           }
+        },
+        "trimmomatic": {
+            "image": "staphb/trimmomatic",
+            "tag": "0.39",
+            "params": {
+                "windowsize": "4",
+                "qscore": "30",
+                "minlength": "100"
+            }
+        },
+        "shovill": {
+            "image": "staphb/shovill",
+            "tag": "1.0.4",
+            "params": ""
+        },
+        "mlst": {
+            "image": "staphb/mlst",
+            "tag": "2.17.6-cv1",
+            "params": ""
+        },
+        "quast": {
+            "image": "staphb/quast",
+            "tag": "5.0.2",
+            "params": {
+                "reference": null
+            }
+        },
+        "abricate": {
+            "image": "staphb/abricate",
+            "tag": "0.9.8-cv1",
+            "params": ""
+        }
+    },
+    "execution":{
+        "run_id": null,
+        "user": null,
+        "date_time": null
+    },
+    "file_io": {
+        "input_files": {
+            "fastqs": null,
+            "reference": null
+        },
+        "output_files": {
+            "trimmed_fastqs": null,
+            "assemblies": null,
+            "mlst": null,
+            "abricate": null,
+            "abricate_summary": null,
+            "quast_report":  null,
+            "log_files": {
+                "qtrim": null,
+                "assembly": null,
+                "quast": null
+            }
+        }
+    }
+}


### PR DESCRIPTION
I was getting this error while trying to use run_Multi:

multiprocessing.pool.MaybeEncodingError: Error sending result: '[<generator object call at 0x7f1c9f8c15e8>]'. Reason: 'TypeError("can't pickle generator objects")'

After lots of testing, I found out it was calldocker.py that was the problem. Changing these lines fixed the issue and Run_multi is working again. Not sure if a similar problem might happen with singularity?

Also fixed printing error in single run() of sb_programs. Toolkit was printing stdout as single characters rather than line by line