### PR TITLE
Allow for custom .bed files for monroe_pe_assembly pipeline

### DIFF
--- a/packaging/setup.py
+++ b/packaging/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="staphb_toolkit",
-    version="1.2.0",
+    version="1.2.1",
     author="Kelsey Florek, Kevin Libuit",
     author_email="kelsey.florek@slh.wisc.edu, kevin.libuit@dgs.virginia.gov",
     description="A ToolKit of commonly used Public Health Bioinformatics Tools",
@@ -16,9 +16,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     entry_points={
-            "console_scripts":[
+        "console_scripts": [
             'staphb-tk = staphb_toolkit.toolkit_apps:main',
-            'staphb-wf = staphb_toolkit.toolkit_workflows:main']},
+            'staphb-wf = staphb_toolkit.toolkit_workflows:main'
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/staphb_toolkit/toolkit_workflows.py
+++ b/staphb_toolkit/toolkit_workflows.py
@@ -47,7 +47,7 @@ def main():
     ##monroe_pe_assembly----------------------------
     subparser_monroe_pe_assembly = monroe_subparsers.add_parser('pe_assembly',help='Assembly SARS-CoV-2 genomes from paired-end read data generated from ARTIC amplicons', add_help=False)
     subparser_monroe_pe_assembly.add_argument('reads_path', type=str,help="path to the location of the reads in a fastq format")
-    subparser_monroe_pe_assembly.add_argument('--primers', type=str,choices=["V1", "V2", "V3"], help="indicate which ARTIC primers were used (V1, V2, or V3)",required=True)
+    subparser_monroe_pe_assembly.add_argument('--primers', type=str, help="indicate which ARTIC primers were used (V1, V2, or V3)",required=True)
     subparser_monroe_pe_assembly.add_argument('--profile', type=str,choices=["docker", "singularity"],help="Nextflow profile. Default will try docker first, then singularity if the docker executable cannot be found.")
     subparser_monroe_pe_assembly.add_argument('--output','-o',metavar="<output_path>",type=str,help="Path to ouput directory, default \"monroe_results\".",default="monroe_results")
     subparser_monroe_pe_assembly.add_argument('--resume', default="", action="store_const",const="-resume",help="resume a previous run")
@@ -262,12 +262,16 @@ def main():
             work = f"-w {args.output}/logs/work"
 
         if args.monroe_command == 'pe_assembly':
+            #check for either standard ARTIC primer version, or a custom config
+            if not args.config and args.primers not in ('V1', 'V2', 'V3'):
+                raise Exception(f"argument --primers: invalid choice: '{args.primers}' (choose from 'V1', 'V2', 'V3') or create a custom config file to specify your own non-ARTIC primers")
             #build command
             command = nextflow_path + f" {config} run {monroe_path}/monroe_pe_assembly.nf {profile} {args.resume} --pipe pe --reads {args.reads_path} --primers {args.primers} --outdir {args.output} -with-trace {args.output}/logs/{exec_time}Monroe_trace.txt -with-report {args.output}/logs/{exec_time}Monroe_execution_report.html {work}"
             #run command using nextflow in a subprocess
             print("Starting the Monroe paired-end assembly:")
             child = pexpect.spawn(command)
             child.interact()
+
 
         if args.monroe_command == 'cluster_analysis':
             #give report template to user if requested

--- a/staphb_toolkit/workflows/monroe/configs/pe_user_config.config
+++ b/staphb_toolkit/workflows/monroe/configs/pe_user_config.config
@@ -62,6 +62,7 @@ threads=4
 //iVar
 params.ivar_mindepth=1
 params.ivar_minfreq=0
+params.primers_prefix="ARTIC-"
 
 
 process {

--- a/staphb_toolkit/workflows/monroe/monroe.config
+++ b/staphb_toolkit/workflows/monroe/monroe.config
@@ -15,6 +15,7 @@ threads=4
 //iVar
 params.ivar_mindepth=1
 params.ivar_minfreq=0
+params.primers_prefix="ARTIC-"
 
 //iqTree
 params.iqtree_model="GTR+G4"

--- a/staphb_toolkit/workflows/monroe/monroe_pe_assembly.nf
+++ b/staphb_toolkit/workflows/monroe/monroe_pe_assembly.nf
@@ -100,7 +100,7 @@ samtools flagstat SC2.bam
 samtools sort -n SC2.bam > SC2_sorted.bam
 samtools fastq -f2 -F4 -1 ${name}_SC2_R1.fastq.gz -2 ${name}_SC2_R2.fastq.gz SC2_sorted.bam -s singletons.fastq.gz
 
-ivar trim -i SC2.bam -b /reference/ARTIC-${params.primers}.bed -p ivar -e
+ivar trim -i SC2.bam -b /reference/${params.primers_prefix}${params.primers}.bed -p ivar -e
 
 samtools sort  ivar.bam > ${name}.sorted.bam
 samtools index ${name}.sorted.bam


### PR DESCRIPTION
resolves #23 

In order to use custom bed files you use a custom config file which should contain two bits of information:
- a `params.primers_prefix` which specifies the file prefix other than "ARTIC-". This value can be set to an empty string for full control of primer file selection with the `--primers` command line arg
- a `docker.runOptions` value for the `ivar` process which mounts the local directory with the custom primers to `/reference`. In this folder, for ivar to run, it also needs [this reference file](https://github.com/artic-network/artic-ncov2019/blob/master/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta.fai).

The behavior for non-custom-config users should be identical, with the minor exception that invalid ARTIC primer version now raise an exception, rather than failing during argument parsing. This change was needed to prevent `argparse()` from invalidating  the argument before we could determine if there was a custom config.

For people with existing custom configs, they would need to update those configs to include `params.primers_prefix = 'ARTIC-'` in order to run the ivar step successfully.