### PR TITLE
Fixing typos

### DIFF
--- a/staphb_toolkit/workflows/cecret/README.md
+++ b/staphb_toolkit/workflows/cecret/README.md
@@ -23,7 +23,7 @@ staphb-wf cecret --reads_type single Sequencing_reads
 
 ## Annotating a collection of fastas
 ```
-staphb-wf cecret --anotation fastas
+staphb-wf cecret --annotation fastas
 ```
 Note: set `params.relatedness = true` in order to get a multiple sequence alignment, SNP matrix, and newick file for the collection of fastas.
 

--- a/staphb_toolkit/workflows/cecret/configs/cecret_config_template.config
+++ b/staphb_toolkit/workflows/cecret/configs/cecret_config_template.config
@@ -1,6 +1,6 @@
 //# Docker Params -------------------------------------------
 //docker.enabled = true
-//docker.runOptions = ""
+//docker.runOptions = '-u \$(id -u):\$(id -g)'
 //docker.sudo = false
 //docker.temp = /tmp
 //docker.remove = true
@@ -48,9 +48,9 @@
 //params.amplicon_bed = "Cecret/configs/nCoV-2019.insert.bed"
 
 //# default memory and cpu usage
-//params.maxcpus = 48
-//params.medcpus = 5
-//params.maxmem = 200G
+//params.maxcpus = '48'
+//params.medcpus = '5'
+//params.maxmem = '200G'
 
 //# Tool toggles
 //params.trimmer = 'ivar'
@@ -61,53 +61,53 @@
 //params.aligner = 'minimap2'
 
 //# For process seqyclean
-//params.cleaner == 'seqyclean'
-//params.seqyclean_contaminant_file="/Adapters_plus_PhiX_174.fasta"
+//params.cleaner = 'seqyclean'
+//params.seqyclean_contaminant_file = "/Adapters_plus_PhiX_174.fasta"
 //params.seqyclean_minlen = 25
 //process {
 //  withName:seqyclean{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/seqyclean:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/seqyclean:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
 
 //# For process fastp
-//params.cleaner == 'fastp'
+//params.cleaner = 'fastp'
 //process {
 //  withName:fastp{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'bromberglab/fastp:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'bromberglab/fastp:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
 
 //# For process bwa
-//params.aligner == 'bwa'
+//params.aligner = 'bwa'
 //process {
 //  withName:bwa{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/bwa:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/bwa:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
 
 //# For process minimap2
-//params.aligner == 'minimap2'
+//params.aligner = 'minimap2'
 //params.minimap2_K = '20M' // stolen from monroe
 //params.minimap2_options = ''
 //process {
 //  withName:minimap2{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/minimap2:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/minimap2:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -115,10 +115,10 @@
 //# For process sort
 //process {
 //  withName:sort{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -128,35 +128,35 @@
 //params.filter = true
 //process {
 //  withName:filter{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
 
 //# For process ivar_trim
-//params.trimmer == 'ivar'
+//params.trimmer = 'ivar'
 //process {
 //  withName:ivar_trim{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/ivar:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/ivar:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
 
 //# For process samtools_ampliconclip
 //params.samtools_ampliconclip_options = ''
-//params.trimmer == 'samtools'
+//params.trimmer = 'samtools'
 //process {
 //  withName:samtools_ampliconclip{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/samtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/samtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -169,10 +169,10 @@
 //params.ivar_variants = true
 //process {
 //  withName:ivar_variants{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/ivar:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/ivar:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -184,13 +184,13 @@
 //params.mpileup_depth = 8000
 //process {
 //  withName:ivar_consensus{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/ivar:latest'
-//    memory {2.GB * task.attempt}
-//    errorStrategy {'retry'}
-//    maxRetries 2
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/ivar:latest'
+//    memory = '{2.GB * task.attempt}'
+//    errorStrategy = 'retry'
+//    maxRetries = '2'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -199,10 +199,10 @@
 //params.bcftools_variants = true
 //process {
 //  withName:bcftools_variants{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/bcftools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/bcftools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -212,13 +212,13 @@
 //params.bamsnap_options = ''
 //process {
 //  withName:bamsnap{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.medpus
-//    errorStrategy 'ignore'
-//    container 'danielmsk/bamsnap:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = 'params.medpus'
+//    errorStrategy = 'ignore'
+//    container = 'danielmsk/bamsnap:latest'
 //    stageInMode = 'symlink'
-//    time '1h'
+//    time = '1h'
 //  }
 //}
 
@@ -227,10 +227,10 @@
 //params.samtools_stats = true
 //process {
 //  withName:samtools_stats{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -240,10 +240,10 @@
 //params.samtools_coverage = true
 //process {
 //  withName:samtools_coverage{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -253,10 +253,10 @@
 //params.samtools_flagstat = true
 //process {
 //  withName:samtools_flagstat{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -268,10 +268,10 @@
 //params.kraken2_organism = "Severe acute respiratory syndrome coronavirus 2"
 //process {
 //  withName:kraken2{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/kraken2:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/kraken2:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -281,10 +281,10 @@
 //params.bedtools_options = '-f .1'
 //process {
 //  withName:bedtools_multicov{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/bedtools:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/bedtools:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -294,10 +294,10 @@
 //params.samtools_ampliconstats = true
 //process {
 //  withName:samtools_ampliconstats{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtool:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtool:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -307,10 +307,10 @@
 //params.samtools_plot_ampliconstats = true
 //process {
 //  withName:samtools_ampliconstats{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/samtool:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/samtool:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -320,10 +320,10 @@
 //params.pangolin = true
 //process {
 //  withName:pangolin{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/pangolin:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/pangolin:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -333,10 +333,10 @@
 //params.nextclade = true
 //process {
 //  withName:nextclade{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'neherlab/nextclade:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'neherlab/nextclade:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -349,11 +349,11 @@
 //params.maxmem = Math.round(Runtime.runtime.totalMemory() / 10241024)
 //process {
 //  withName:vadr{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.medcpus
-//    memory params.maxmem
-//    container 'staphb/vadr:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = 'params.medpus'
+//    memory = 'params.maxmem'
+//    container = 'staphb/vadr:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -361,10 +361,10 @@
 //# For process summary
 //process {
 //  withName:summary{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/parallel-perl:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/parallel-perl:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -372,10 +372,10 @@
 //# For process combined_summary
 //process {
 //  withName:combined_summary{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/parallel-perl:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/parallel-perl:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -386,12 +386,12 @@
 //params.relatedness = true
 //process {
 //  withName:mafft{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/mafft:latest'
-//    errorStrategy 'retry'
-//    maxRetries 2
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/mafft:latest'
+//    errorStrategy = 'retry'
+//    maxRetries = '2'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -401,10 +401,10 @@
 //params.snpdists = true
 //process {
 //  withName:snpdists{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/snp-dists:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/snp-dists:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -412,14 +412,14 @@
 //# For process iqtree
 //params.iqtree_options = ''
 //params.outgroup = 'MN908947.3'
-//params.mode='GTR'
+//params.mode = 'GTR'
 //params.iqtree = true
 //process {
 //  withName:iqtree{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus params.maxcpus
-//    container 'staphb/iqtree:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = "params.maxcpus"
+//    container = 'staphb/iqtree:latest'
 //    stageInMode = 'symlink'
 //  }
 //}
@@ -431,10 +431,10 @@
 //params.genbank_threshold = '15000'
 //process {
 //  withName:rename{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/parallel-perl:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/parallel-perl:latest'
 //    stageInMode = 'copy'
 //  }
 //}
@@ -442,10 +442,10 @@
 //# For process fasta_prep
 //process {
 //  withName:fasta_prep{
-//    publishDir "cecret, mode: 'copy'
-//    echo false
-//    cpus 1
-//    container 'staphb/parallel-perl:latest'
+//    publishDir = "cecret, mode: 'copy'
+//    echo = 'false'
+//    cpus = '1'
+//    container = 'staphb/parallel-perl:latest'
 //    stageInMode = 'symlink'
 //  }
 //}


### PR DESCRIPTION
I forgot to include '=' in my sample config file, so it throws errors

It should throw fewer errors now

Also, annotation has three n's, not two.