### PR TITLE
Cecret multifasta support

### DIFF
--- a/staphb_toolkit/toolkit_workflows.py
+++ b/staphb_toolkit/toolkit_workflows.py
@@ -154,7 +154,7 @@ def main():
     #cecret-----------------------------------------
     parser_cecret = subparsers.add_parser('cecret', help='Consensus fasta creation of amplicon-based SARS-CoV-2 Illumina sequencing.', add_help=False)
     parser_cecret.add_argument('reads_path', type=str,help="path to the location of reads in a fastq format",nargs='?', default=False)
-    parser_cecret.add_argument('--reads_type',type=str,choices=["paired","single","fasta"],help="Specify either \"paired\"-end or \"single\"-end reads or \"fasta\" files, default \"paired\".",default="paired")
+    parser_cecret.add_argument('--reads_type',type=str,choices=["paired","single","fasta","multifasta"],help="Specify either \"paired\"-end or \"single\"-end reads and/or \"fasta\" or \"multifasta\" files, default \"paired\".",default="paired")
     parser_cecret.add_argument('--output','-o',metavar="<output_path>",type=str,help="Path to ouput directory, default \"cecret\".",default="cecret")
     parser_cecret.add_argument('--profile',type=str,choices=["docker","singularity"],help="Nextflow profile. Default will try docker first, then singularity if the docker executable cannot be found.")
     parser_cecret.add_argument('--config','-c',type=str,help="Nextflow custom configuration.")
@@ -674,6 +674,8 @@ def main():
             reads_type = "--single_reads"
         elif args.reads_type == "fasta":
             reads_type = "--fastas"
+        elif args.reads_type == "multifasta":
+            reads_type = "--multifastas"
         elif not args.reads_type:
             print("Type of reads not specified for some reason")
             sys.exit(1)

--- a/staphb_toolkit/workflows/cecret/bin/combine_results.py
+++ b/staphb_toolkit/workflows/cecret/bin/combine_results.py
@@ -1,0 +1,53 @@
+#!/bin/python
+
+import pandas as pd
+from os.path import exists
+
+pangolin_file='lineage_report.csv'
+nextclade_file='nextclade.csv'
+vadr_file='vadr.csv'
+summary_file='combined_summary.csv'
+
+summary_df = pd.read_csv(summary_file, dtype = str)
+
+if exists(pangolin_file) :
+    pangolin_df = pd.read_csv(pangolin_file, dtype = str, usecols = ['taxon', 'status', 'scorpio_call', 'version', 'pangolin_version', 'pango_version', 'pangoLEARN_version'])
+    pangolin_df['simple_name'] = pangolin_df['taxon'].replace('Consensus_','', regex=True).replace('.consensus.*', '', regex=True)
+    pangolin_df=pangolin_df.add_prefix('pangolin_')
+
+    summary_df = pd.merge(summary_df, pangolin_df, left_on = 'sample', right_on = 'pangolin_simple_name', how = 'outer')
+
+    summary_df['sample_id'] = summary_df.loc[summary_df['sample_id'].ne('null'), 'pangolin_taxon']
+    summary_df['sample'] = summary_df.loc[summary_df['sample'].ne('null'), 'pangolin_simple_name']
+
+    summary_df.drop('pangolin_simple_name', axis=1, inplace=True)
+    summary_df.drop('pangolin_taxon', axis=1, inplace=True)
+
+if exists(nextclade_file) :
+    nextclade_df = pd.read_csv(nextclade_file, sep = ';' , dtype = str, usecols = ['seqName', 'clade', 'qc.overallStatus', 'qc.overallScore'])
+    nextclade_df['simple_name'] = nextclade_df['seqName'].replace('Consensus_','', regex=True).replace('.consensus.*', '', regex=True)
+    nextclade_df=nextclade_df.add_prefix('nextclade_')
+
+    summary_df = pd.merge(summary_df, nextclade_df, left_on = 'sample', right_on = 'nextclade_simple_name', how = 'outer')
+
+    summary_df['sample_id'] = summary_df.loc[summary_df['sample_id'].ne('null'), 'nextclade_seqName']
+    summary_df['sample'] = summary_df.loc[summary_df['sample'].ne('null'), 'nextclade_simple_name']
+
+    summary_df.drop('nextclade_simple_name', axis=1, inplace=True)
+    summary_df.drop('nextclade_seqName', axis=1, inplace=True)
+
+if exists(vadr_file) :
+    vadr_df = pd.read_csv(vadr_file, dtype = str, usecols = ['name', 'p/f', 'model', 'alerts'])
+    vadr_df['simple_name'] = vadr_df['name'].replace('Consensus_','', regex=True).replace('.consensus.*', '', regex=True)
+    vadr_df=vadr_df.add_prefix('vadr_')
+
+    summary_df = pd.merge(summary_df, vadr_df, left_on = 'sample', right_on = 'vadr_simple_name', how = 'outer')
+
+    # This currently erases the columns that were there for some reason
+    #summary_df['sample_id'] = summary_df.loc[summary_df['sample_id'].ne('null'), 'vadr_name']
+    #summary_df['sample'] = summary_df.loc[summary_df['sample'].ne('null'), 'vadr_simple_name']
+
+    summary_df.drop('vadr_simple_name', axis=1, inplace=True)
+    summary_df.drop('vadr_name', axis=1, inplace=True)
+
+summary_df.to_csv('cecret_results.csv')

--- a/staphb_toolkit/workflows/cecret/cecret.nf
+++ b/staphb_toolkit/workflows/cecret/cecret.nf
@@ -1538,7 +1538,7 @@ if (params.relatedness) {
       maxRetries 2
 
       input:
-      file(consensus) from consensus_msa.concat(fastas_msa).concat(multifastas_msa)
+      file(consensus) from consensus_msa.concat(fastas_msa).concat(multifastas_msa).collect()
       file(reference_genome) from reference_genome_msa
 
       output:
@@ -1555,9 +1555,9 @@ if (params.relatedness) {
         echo "mafft version:" >> $log_file
         mafft --version 2>&1 >> $log_file
 
-        for fasta in !{task.process}/!{consensus}
+        for fasta in !{consensus}
         do
-          cat $fasta >> ultimate.fasta
+          cat $fasta >> !{task.process}/ultimate.fasta
         done
 
         mafft --auto \
@@ -1578,7 +1578,7 @@ if (params.relatedness) {
       container 'nextstrain/nextalign:latest'
 
       input:
-      file(consensus) from consensus_msa.concat(fastas_msa).concat(multifastas_msa)
+      file(consensus) from consensus_msa.concat(fastas_msa).concat(multifastas_msa).collect()
       path(dataset) from prepped_nextalign
 
       output:

--- a/staphb_toolkit/workflows/cecret/cecret.nf
+++ b/staphb_toolkit/workflows/cecret/cecret.nf
@@ -3,7 +3,7 @@
 println("Currently using the Cecret workflow for use with amplicon-based Illumina hybrid library prep on MiSeq\n")
 println("Author: Erin Young")
 println("email: eriny@utah.gov")
-println("Version: v.2.2.20211213")
+println("Version: v.2.2.20211215")
 println("")
 
 params.reads = workflow.launchDir + '/reads'

--- a/staphb_toolkit/workflows/cecret/cecret.nf
+++ b/staphb_toolkit/workflows/cecret/cecret.nf
@@ -35,7 +35,7 @@ Channel
   .into { paried_reads_check ; paired_reads }
 
 Channel
-  .fromPath("${params.single_reads}/*.{fastq,fastq.gz,fq,fz.gz}")
+  .fromPath("${params.single_reads}/*.{fastq,fastq.gz,fq,fq.gz}")
   .map { reads -> tuple(reads.simpleName, reads, "single" ) }
   .view { "Fastq file found : ${it[0]}" }
   .into { single_reads_check ; single_reads }

--- a/staphb_toolkit/workflows/cecret/configs/cecret_config_template.config
+++ b/staphb_toolkit/workflows/cecret/configs/cecret_config_template.config
@@ -61,6 +61,7 @@ params.medcpus = 4
 //params.aligner = 'bwa'
 //params.aligner = 'minimap2'
 //params.msa = 'mafft'
+//params.msa = 'nextclade'
 //params.msa = 'nextalign'
 
 //# Docker Images -------------------------------------------
@@ -83,6 +84,7 @@ mafft_container = 'staphb/mafft:latest'
 nextalign_container = 'nextstrain/nextalign:latest'
 snp_dists_container = 'staphb/snp-dists:latest'
 iqtree2_container = 'staphb/iqtree2:latest'
+pandas_container = 'quay.io/biocontainers/pandas:1.1.5'
 
 //# Workflow parameters --------------------------------------
 
@@ -192,12 +194,8 @@ iqtree2_container = 'staphb/iqtree2:latest'
 //params.pangolin_options = ''
 //params.pangolin = true
 
-//# For process nextclade_prep - either nextclade must be true or the msa must be done by nextalign
-//params.nextclade = true
-//params.msa == 'nextalign'
-//params.nextclade_prep_options = '--name sars-cov-2'
-
 //# For process nextclade
+//params.nextclade_dataset = 'sars-cov-2'
 //params.nextclade_options = ''
 //params.nextclade = true
 
@@ -297,7 +295,7 @@ process {
   }
 
   withName:fasta_prep{
-    container = parallel_perl_container
+    container = pandas_container
   }
 
   withName:bcftools_variants{
@@ -347,10 +345,6 @@ process {
     container = pangolin_container
   }
 
-  withName:nextclade_prep{
-    container = nextclade_container
-  }
-
   withName:nextclade{
     cpus = params.medcpus
     container = nextclade_container
@@ -363,7 +357,11 @@ process {
   }
 
   withName:summary{
-    container = parallel_perl_container
+    container = pandas_container
+  }
+
+  withName:combine_results{
+    container = pandas_container
   }
 
   withName:mafft{


### PR DESCRIPTION
A couple of things have happened:
1. There's now multifasta support. This caused a chain of changes including
  - running vadr, nextclade, and pangolin on the collection of samples instead of individually
  - combining the nextclade_prep and nextclade processes because nextclade is now only run once
  - utilization of the aligned multifasta that is output with nexclade
  - a new python script dependent on pandas for combining results at the end
  - adjusting the fasta_prep and summary process to now use the quay pandas container 
 2. Also a few bug fixes 
  - fixing the container so that docker can read it 
  - fixed some workflow bugs for when trimmer is set to 'none'
  - and more